### PR TITLE
Add teams handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# AWS-to-Slack
+# AWS Notifications
 
 [![npm](https://img.shields.io/npm/v/aws-to-slack.svg)](https://www.npmjs.com/package/aws-to-slack)
 [![license](https://img.shields.io/github/license/arabold/aws-to-slack.svg)](https://github.com/arabold/aws-to-slack/blob/master/LICENSE)
 [![dependencies](https://img.shields.io/david/arabold/aws-to-slack.svg)](https://www.npmjs.com/package/aws-to-slack)
 
 
-Forward AWS CloudWatch Alarms and other notifications from Amazon SNS to Slack.
+Forward AWS CloudWatch Alarms and other notifications from Amazon SNS to Slack or Microsoft Teams.
 
 <table>
    <tr>
@@ -19,10 +19,14 @@ Forward AWS CloudWatch Alarms and other notifications from Amazon SNS to Slack.
 </table>
 
 ## What is it?
-_AWS-to-Slack_ is a Lambda function written in Node.js that forwards alarms and
-notifications to a dedicated [Slack](https://slack.com) channel. It is self-hosted
+_AWS Notifications_ is a Lambda function written in Node.js that forwards alarms and
+notifications to [Slack](https://slack.com) or [Microsoft Teams](https://teams.microsoft.com) channels. It is self-hosted
 in your own AWS environment and doesn't have any 3rd party dependencies other
 than the Google Charts API for rendering CloudWatch metrics.
+
+**Supported Platforms:**
+* Slack (via Incoming Webhooks)
+* Microsoft Teams (via Incoming Webhooks or Power Automate)
 
 Supported AWS product notification formats:
 * Auto-Scaling Events
@@ -34,6 +38,7 @@ Supported AWS product notification formats:
 * CodeDeploy 🆕 _(via SNS/CloudWatch)_
 * CodePipeline 🆕 _(via SNS/CloudWatch)_
 * CodePipeline Manual Approval 🆕
+* Config
 * Elastic Beanstalk
 * Event-bridge (AWS Config Compliance Change, Remediation Execution Status Change, Remediation Execution Failures) 🆕
 * GuardDuty 🆕
@@ -83,7 +88,9 @@ See [Managing Multiple Deployments](#managing-multiple-deployments) for a `.env`
 
 ## Installation
 
-### Step 1: Setup Slack
+### Step 1: Setup Notification Platform
+
+#### For Slack:
 The Lambda function communicates with Slack through a Slack webhook
 [webhook](https://my.slack.com/apps/manage). Note that you can either create an app, or a custom integration > Incoming webhook (easier, will only let you add a webhook)
 
@@ -97,6 +104,13 @@ The Lambda function communicates with Slack through a Slack webhook
 
 ![Slack Configuration](./docs/config-slack.png)
 
+#### For Microsoft Teams:
+1. In Teams, go to the channel where you want to receive notifications
+2. Click the three dots (...) next to the channel name
+3. Select "Connectors" or "Workflows" > "Incoming Webhook"
+4. Configure the webhook and copy the URL
+5. Use this URL in the CloudFormation template
+
 ### Step 2: Configure & Launch the CloudFormation Stack
 
 Note that the AWS region will be the region from which you launch the CloudFormation wizard, which will also scope the resources (SNS, etc.) to that region. 
@@ -107,8 +121,9 @@ Launch the CloudFormation Stack by using our preconfigured CloudFormation
 **Afterwards**
 
 Click "Next" and on the following page name your new stack and paste the
-webhook URL from before into the "HookUrl" field. You can also configure a
-different channel to post to if wanted.
+webhook URL (Slack or Teams) from before into the "HookUrl" field. The Lambda
+will automatically detect the platform and format messages appropriately. You can also configure a
+different channel to post to if wanted (Slack only).
 
 ![AWS CloudFormation Configuration](./docs/config-stack.png)
 
@@ -122,7 +137,7 @@ The Makefile found in this repository assists with the deployment of the tool. T
 1. Create a `.env` file that includes the following as a minumum:
    ```
    STACK_NAME=aws-to-slack
-   STACK_PARAMS="ParameterKey=HookUrl,ParameterValue=<https://hooks.slack.com/services/<YOUR_SLACK_WEBHOOK>>"
+   STACK_PARAMS="ParameterKey=HookUrl,ParameterValue=<YOUR_WEBHOOK_URL>"
    ```
 2. Configure your AWS Credentials via CLI
 3. Use the `make create-stack TARGET=.env` command to create the Cloudformation stack
@@ -146,7 +161,7 @@ Randy Findley.
 To enable CodeBuild notifications add a new _CloudWatch Event Rule_, choose _CodeBuild_
 as source and _CodeBuild Build State Change_ as type. As Target select the `aws-to-slack`
 Lambda. You can leave all other settings as is. Once your rule is created all CodeBuild
-build state events will be forwarded to your Slack channel.
+build state events will be forwarded to your notification channel.
 
 ### Setting Up AWS CodeCommit
 
@@ -159,7 +174,7 @@ as the source, and select one of the supported event types:
 * _CodeCommit Repository State Change_ - Will generate events when a branch
   or tag reference is created, updated, or deleted.
 
-Add the `aws-to-slack` lambda as the target. No other settings are needed.
+Add the `aws-notifications` lambda as the target. No other settings are needed.
 
 ## Managing Multiple Deployments
 

--- a/src/eventdef.js
+++ b/src/eventdef.js
@@ -280,8 +280,8 @@ class SlackLink {
 }
 
 /**
- * Clone so sub-modules never have to explicitly import the Slack module.
+ * Clone so sub-modules never have to explicitly import the notifications module.
  */
-EventDef.COLORS = require("./slack").COLORS;
+EventDef.COLORS = require("./notifications").COLORS;
 
 module.exports = EventDef;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const _ = require("lodash")
 	, EventDef = require("./eventdef")
-	, Slack = require("./slack")
+	, Notifications = require("./notifications")
 	, Emailer = require("./ses")
 	, defaultParserWaterfall = [
 		// Ordered list of parsers:
@@ -147,8 +147,8 @@ class LambdaHandler {
 					const res = await handler.processEvent(new EventDef(singleRecordEvent));
 					if (res) {
 						const message = res.slackMessage;
-						console.log(`SNS-Record[${i}]: Sending Slack message from Parser[${res.parserName}]:`, JSON.stringify(message, null, 2));
-						waitingTasks.push(Slack.postMessage(message));
+						console.log(`SNS-Record[${i}]: Sending notification from Parser[${res.parserName}]:`, JSON.stringify(message, null, 2));
+						waitingTasks.push(Notifications.postMessage(message));
 						waitingTasks.push(Emailer.checkAndSend(message, event));
 					}
 					else if (handler.lastParser) {
@@ -163,8 +163,8 @@ class LambdaHandler {
 				const res = await handler.processEvent(new EventDef(event));
 				if (res) {
 					const message = res.slackMessage;
-					console.log(`Sending Slack message from Parser[${res.parserName}]:`, JSON.stringify(message, null, 2));
-					waitingTasks.push(Slack.postMessage(message));
+					console.log(`Sending notification from Parser[${res.parserName}]:`, JSON.stringify(message, null, 2));
+					waitingTasks.push(Notifications.postMessage(message));
 					waitingTasks.push(Emailer.checkAndSend(message, event));
 				}
 				else if (handler.lastParser) {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -3,13 +3,13 @@ const url = require("url")
 	, AWS = require("aws-sdk")
 	, _ = require("lodash");
 
-/** The Slack hook URL */
+/** The webhook URL (Slack or Teams) */
 const hookUrlPromise = shouldDecryptBlob(process.env.SLACK_HOOK_URL, s =>
 	// URL should be 78-80 characters long when decrypted
 	s.length > 100 && !/https?:\/\/\w/.test(s));
 
-/** The Slack channel to send a message to stored in the slackChannel environment variable */
-const slackChannelPromise = shouldDecryptBlob(process.env.SLACK_CHANNEL);
+/** The channel to send a message to (Slack only) */
+const channelPromise = shouldDecryptBlob(process.env.SLACK_CHANNEL);
 
 /**
  * Decrypt environment variable if it looks like a KMS encrypted string.
@@ -44,11 +44,11 @@ function shouldDecryptBlob(blob, isValid) {
 }
 
 /**
- * Slack Helper Utility
+ * Notification Helper Utility (Slack & Teams)
  */
-class Slack {
+class Notifications {
 	/**
-	 * Converts a given {@link Date} object to a Slack-compatible epoch timestamp.
+	 * Converts a given {@link Date} object to an epoch timestamp.
 	 *
 	 * @param {Date} date - Date object to convert
 	 * @returns {Integer} Epoch time
@@ -58,20 +58,24 @@ class Slack {
 	}
 
 	/**
-	 * Posts a message to Slack.
+	 * Posts a message to Slack or Teams.
 	 *
-	 * @param {Object} message - Message to post to Slack
+	 * @param {Object} message - Message to post to Slack or Teams
 	 * @returns {Promise} Fulfills on success, rejects on error.
 	 */
 	static postMessage(message) {
 		return retry(3, async () => {
 			const hookUrl = await hookUrlPromise;
-			const slackChannel = await slackChannelPromise;
-			if (_.isEmpty(message.channel) && !_.isEmpty(slackChannel)) {
-				message.channel = slackChannel;
+			const channel = await channelPromise;
+			if (_.isEmpty(message.channel) && !_.isEmpty(channel)) {
+				message.channel = channel;
 			}
 
-			const response = await postJson(message, hookUrl);
+			// Check if this is a Teams webhook and convert message format
+			const isTeamsWebhook = hookUrl.includes('office.com') || hookUrl.includes('outlook.com') || hookUrl.includes('azure.com');
+			const payload = isTeamsWebhook ? this.convertToTeamsFormat(message) : message;
+
+			const response = await postJson(payload, hookUrl);
 			const statusCode = response.statusCode;
 
 			if (200 <= statusCode && statusCode < 300) {
@@ -79,20 +83,89 @@ class Slack {
 				return response;
 			}
 			if (400 <= statusCode && statusCode < 500) {
-				const e = new Error(`Slack API reports bad request [HTTP:${response.statusCode}] ${response.statusMessage}: ${response.body}`);
+				const e = new Error(`Webhook API reports bad request [HTTP:${response.statusCode}] ${response.statusMessage}: ${response.body}`);
 				e.retryable = false;
 				throw e;
 			}
 
-			throw `Slack API error [HTTP:${response.statusCode}]: ${response.body}`;
+			throw `Webhook API error [HTTP:${response.statusCode}]: ${response.body}`;
 		});
+	}
+
+	/**
+	 * Converts message format to Teams format.
+	 *
+	 * @param {Object} message - Standard message format
+	 * @returns {Object} Teams formatted message
+	 */
+	static convertToTeamsFormat(message) {
+		// Keep attachments array structure for Power Automate compatibility
+		return {
+			attachments: message.attachments?.map(attachment => ({
+				contentType: "application/vnd.microsoft.card.adaptive",
+				content: {
+					"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+					type: "AdaptiveCard",
+					version: "1.2",
+					body: [
+						{
+							type: "TextBlock",
+							text: attachment.author_name || "AWS Notification",
+							weight: "Bolder",
+							size: "Medium"
+						},
+						{
+							type: "TextBlock",
+							text: attachment.title || "",
+							weight: "Bolder"
+						},
+						{
+							type: "TextBlock",
+							text: attachment.text || "",
+							wrap: true
+						},
+						...(attachment.fields?.map(field => ({
+							type: "FactSet",
+							facts: [{
+								title: field.title,
+								value: field.value
+							}]
+						})) || [])
+					],
+					...(attachment.title_link && {
+						actions: [{
+							type: "Action.OpenUrl",
+							title: "View in AWS Console",
+							url: attachment.title_link
+						}]
+					})
+				}
+			})) || []
+		};
+	}
+
+	/**
+	 * Maps color names to hex values for Teams.
+	 *
+	 * @param {string} color - Color name or hex
+	 * @returns {string} Hex color value
+	 */
+	static mapColorToHex(color) {
+		const colorMap = {
+			danger: "FF324D",
+			warning: "FFD602",
+			good: "8CC800",
+			"#1E90FF": "1E90FF",
+			"#A8A8A8": "A8A8A8"
+		};
+		return colorMap[color] || color?.replace('#', '') || "1E90FF";
 	}
 }
 
 /**
  * Set of predefined colors for different alert levels
  */
-Slack.COLORS = {
+Notifications.COLORS = {
 	critical: "danger",  // "#FF324D",
 	warning: "warning", // "#FFD602",
 	ok: "good",    // "#8CC800",
@@ -175,4 +248,4 @@ function postJson(data, endpoint) {
 	});
 }
 
-module.exports = Slack;
+module.exports = Notifications;


### PR DESCRIPTION

- Adds the ability to handle pointing the tool at Teams Webhooks. The lambda automatically picks up if the endpoint is a Teams webhook based on the webhook itself and handles the conversion to a Teams compatible message.
- Updates naming and documentation to make clear that this now supports more than just Slack

